### PR TITLE
Removed 'USER app' to fix issue with podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY --from=build /app/publish /app
 ENTRYPOINT ["dotnet", "/app/SqliteArchive.Server.dll"]
 
 HEALTHCHECK --start-period=1m --start-interval=1s \
-  CMD wget --no-verbose --tries=1 --spider http://localhost || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:${ASPNETCORE_HTTP_PORTS} || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
 
 RUN apk add --no-cache tzdata icu-libs
 
-USER app
 WORKDIR /srv
 EXPOSE 80 21 10000-10009
 


### PR DESCRIPTION
When running under podman, the server failed with "SocketException (13): Permission denied". The cause turned out to be the `USER app` in the Dockerfile:

Under docker, ip_unprivileged_port_start in the container is 0 even if it's 1024 on the host:

```
❯ docker run -it --rm --user 1000 alpine
~ $ cat /proc/sys/net/ipv4/ip_unprivileged_port_start
0
~ $

❯ cat /proc/sys/net/ipv4/ip_unprivileged_port_start
1024
```

This is why the server could bind to port 80 in the container despite running as a non-root user. ([Apparently this was a change Docker made in 2020.](https://medium.com/@olivier.gaumond/why-am-i-able-to-bind-a-privileged-port-in-my-container-without-the-net-bind-service-capability-60972a4d5496))

Under podman, however, ip_unprivileged_port_start is the default 1024:

```
❯ podman run -it --rm --user 1000 alpine
~ $ cat /proc/sys/net/ipv4/ip_unprivileged_port_start
1024
~ $
```

This is the case even if it's set to 0 on the host (either temporarily via sysctl or permanently by creating a file in /etc/sysctl.d), so the host's setting is basically irrelevant except for port binding host-side.

Which means that ironically, on the rootless engine, the container user needs to be root or it can't bind to port 80 (of course it's really the current user on the host that's being mapped to the root user in the container, but the container doesn't know that).

There are other ways to work around this, e.g. setting the NET_BIND_SERVICE capability, running the container with --sysctl, or changing the ports in the container to be >1024, but I'd rather keep the ports as they are and not need special flags to run in podman.

Set `--user app` when running the container to use the non-root user. Additionally, `ASPNETCORE_HTTP_PORTS` can be set to override the container port if necessary (e.g. `docker run -it --rm -v .:/srv:ro -p 3939:3939 --user app -e ASPNETCORE_HTTP_PORTS=3939 kagamine/sqlarserver`). I've modified the healthcheck to use this env var rather than assume port 80. The FTP server is still hardcoded to port 21, but if there's interest, we could add an `FtpPort` (and a shorter `Port` for HTTP) option to change that.